### PR TITLE
Fix typos in README and configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ To train on your custom dataset, you need to organize it in the COCO format. Fol
       num_workers: 4
       drop_last: True 
       collate_fn:
-        type: BatchImageCollateFuncion
+        type: BatchImageCollateFunction
     
     val_dataloader:
       type: DataLoader
@@ -331,7 +331,7 @@ To train on your custom dataset, you need to organize it in the COCO format. Fol
       num_workers: 4
       drop_last: False
       collate_fn:
-        type: BatchImageCollateFuncion
+        type: BatchImageCollateFunction
     ```
 
 </details>
@@ -379,7 +379,7 @@ export model=l  # s m l x
 CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --master_port=7777 --nproc_per_node=4 train.py -c configs/dfine/objects365/dfine_hgnetv2_${model}_obj365.yml --use-amp --seed=0
 ```
 
-3. Turning on COCO2017
+3. Tuning on COCO2017
 ```shell
 CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --master_port=7777 --nproc_per_node=4 train.py -c configs/dfine/objects365/dfine_hgnetv2_${model}_obj2coco.yml --use-amp --seed=0 -t model.pth
 ```

--- a/README_cn.md
+++ b/README_cn.md
@@ -310,7 +310,7 @@ python tools/resize_obj365.py --base_dir ${BASE_DIR}
       num_workers: 4
       drop_last: True 
       collate_fn:
-        type: BatchImageCollateFuncion
+        type: BatchImageCollateFunction
     
     val_dataloader:
       type: DataLoader
@@ -326,7 +326,7 @@ python tools/resize_obj365.py --base_dir ${BASE_DIR}
       num_workers: 4
       drop_last: False
       collate_fn:
-        type: BatchImageCollateFuncion
+        type: BatchImageCollateFunction
     ```
 </details>
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -318,7 +318,7 @@ python tools/resize_obj365.py --base_dir ${BASE_DIR}
       num_workers: 4
       drop_last: True 
       collate_fn:
-        type: BatchImageCollateFuncion
+        type: BatchImageCollateFunction
     
     val_dataloader:
       type: DataLoader
@@ -334,7 +334,7 @@ python tools/resize_obj365.py --base_dir ${BASE_DIR}
       num_workers: 4
       drop_last: False
       collate_fn:
-        type: BatchImageCollateFuncion
+        type: BatchImageCollateFunction
     ```
 
 </details>

--- a/configs/dataset/coco_detection.yml
+++ b/configs/dataset/coco_detection.yml
@@ -21,7 +21,7 @@ train_dataloader:
   num_workers: 4
   drop_last: True 
   collate_fn:
-    type: BatchImageCollateFuncion
+    type: BatchImageCollateFunction
 
 
 val_dataloader:
@@ -38,4 +38,4 @@ val_dataloader:
   num_workers: 4
   drop_last: False
   collate_fn:
-    type: BatchImageCollateFuncion
+    type: BatchImageCollateFunction

--- a/configs/dataset/custom_detection.yml
+++ b/configs/dataset/custom_detection.yml
@@ -21,7 +21,7 @@ train_dataloader:
   num_workers: 4
   drop_last: True 
   collate_fn:
-    type: BatchImageCollateFuncion
+    type: BatchImageCollateFunction
 
 
 val_dataloader:
@@ -38,4 +38,4 @@ val_dataloader:
   num_workers: 4
   drop_last: False
   collate_fn:
-    type: BatchImageCollateFuncion
+    type: BatchImageCollateFunction

--- a/configs/dataset/obj365_detection.yml
+++ b/configs/dataset/obj365_detection.yml
@@ -21,7 +21,7 @@ train_dataloader:
   num_workers: 4
   drop_last: True 
   collate_fn:
-    type: BatchImageCollateFuncion
+    type: BatchImageCollateFunction
 
 
 val_dataloader:
@@ -38,4 +38,4 @@ val_dataloader:
   num_workers: 4
   drop_last: False
   collate_fn:
-    type: BatchImageCollateFuncion
+    type: BatchImageCollateFunction

--- a/configs/dataset/voc_detection.yml
+++ b/configs/dataset/voc_detection.yml
@@ -20,7 +20,7 @@ train_dataloader:
   num_workers: 4
   drop_last: True 
   collate_fn:
-    type: BatchImageCollateFuncion
+    type: BatchImageCollateFunction
 
 
 val_dataloader:
@@ -37,4 +37,4 @@ val_dataloader:
   num_workers: 4
   drop_last: False
   collate_fn:
-    type: BatchImageCollateFuncion
+    type: BatchImageCollateFunction

--- a/configs/dfine/include/dataloader.yml
+++ b/configs/dfine/include/dataloader.yml
@@ -18,7 +18,7 @@ train_dataloader:
         ops: ['RandomPhotometricDistort', 'RandomZoomOut', 'RandomIoUCrop']
   
   collate_fn:
-    type: BatchImageCollateFuncion
+    type: BatchImageCollateFunction
     base_size: 640
     base_size_repeat: 3
     stop_epoch: 72 # epoch in [72, ~) stop `multiscales`

--- a/src/data/dataloader.py
+++ b/src/data/dataloader.py
@@ -22,7 +22,7 @@ from ..core import register
 __all__ = [
     'DataLoader',
     'BaseCollateFunction', 
-    'BatchImageCollateFuncion',
+    'BatchImageCollateFunction',
     'batch_image_collate_fn'
 ]
 
@@ -86,7 +86,7 @@ def generate_scales(base_size, base_size_repeat):
 
 
 @register()
-class BatchImageCollateFuncion(BaseCollateFunction):
+class BatchImageCollateFunction(BaseCollateFunction):
     def __init__(
         self, 
         stop_epoch=None, 


### PR DESCRIPTION
Fix typos in README (Line 382: Turning -> Tuning) and configuration files (In multiple files: BatchImageCollateFuncion -> BatchImageCollateFunction)