### PR TITLE
Fix exporting onnx file that can only be used for inference with max batch size of 1

### DIFF
--- a/tools/deployment/export_onnx.py
+++ b/tools/deployment/export_onnx.py
@@ -51,7 +51,7 @@ def main(args, ):
 
     model = Model()
 
-    data = torch.rand(1, 3, 640, 640)
+    data = torch.rand(32, 3, 640, 640)
     size = torch.tensor([[640, 640]])
     _ = model(data, size)
 


### PR DESCRIPTION
Currently, if you export an onnx file, and then you try to do an inference with a single input of batch size two  (and with `orig_target_sizes=[[640,640],[640,640]]`), you get the following error:

```
2024-11-06 20:50:18.781564629 [E:onnxruntime:, sequential_executor.cc:516 ExecuteKernel] Non-zero status code returned while running GatherElements node. Name:'/model/decoder/GatherElements' Status Message: GatherElements op: 'indices' shape should have values within bounds of 'data' shape. Invalid value in indices shape is: 2
```

This is likely because the onnx was exported with a `model` that was warmed up using a batch-size of `1` in the line that has been changed in this PR.

Hence, instead exporting an onnx file with a higher batch-size. **NOTE:** This will still work with smaller batch sizes like 1,2,4,etc.