### PR TITLE
Fix: fix ddp

### DIFF
--- a/src/zoo/dfine/denoising.py
+++ b/src/zoo/dfine/denoising.py
@@ -25,7 +25,12 @@ def get_contrastive_denoising_training_group(targets,
 
     max_gt_num = max(num_gts)
     if max_gt_num == 0:
-        return None, None, None, None
+        dn_meta = {
+            "dn_positive_idx": None,
+            "dn_num_group": 0,
+            "dn_num_split": [0, num_queries]
+        }
+        return None, None, None, dn_meta
 
     num_group = num_denoising // max_gt_num
     num_group = 1 if num_group == 0 else num_group

--- a/src/zoo/dfine/dfine_criterion.py
+++ b/src/zoo/dfine/dfine_criterion.py
@@ -334,6 +334,7 @@ class DFINECriterion(nn.Module):
             assert 'dn_meta' in outputs, ''
             indices_dn = self.get_cdn_matched_indices(outputs['dn_meta'], targets)
             dn_num_boxes = num_boxes * outputs['dn_meta']['dn_num_group']
+            dn_num_boxes = dn_num_boxes if dn_num_boxes > 0 else 1
 
             for i, aux_outputs in enumerate(outputs['dn_outputs']):
                 aux_outputs['is_dn'] = True

--- a/src/zoo/dfine/dfine_criterion.py
+++ b/src/zoo/dfine/dfine_criterion.py
@@ -154,7 +154,9 @@ class DFINECriterion(nn.Module):
             if 'teacher_corners' in outputs:
                 pred_corners = outputs['pred_corners'].reshape(-1, (self.reg_max+1))
                 target_corners = outputs['teacher_corners'].reshape(-1, (self.reg_max+1))
-                if not torch.equal(pred_corners, target_corners):
+                if torch.equal(pred_corners, target_corners):
+                    losses['loss_ddf'] = pred_corners.sum() * 0
+                else:
                     weight_targets_local = outputs['teacher_logits'].sigmoid().max(dim=-1)[0]
 
                     mask = torch.zeros_like(weight_targets_local, dtype=torch.bool)


### PR DESCRIPTION
Fixes #39
修正了多进程训练时，个别进程可能因为gt为0，导致模型输出没有以dn_结尾的结果。进而导致损失中'loss_vfl_dn_{id}', 'loss_bbox_dn_{id}', 'loss_giou_dn_{id}', 'loss_fgl_dn_{id}', 'loss_ddf_dn_{id}', 'loss_vfl_dn_{id}'不存在，导致训练卡死的问题