### PR TITLE
add wandb integration/logging

### DIFF
--- a/configs/runtime.yml
+++ b/configs/runtime.yml
@@ -18,3 +18,6 @@ ema:
   type: ModelEMA
   decay: 0.9999
   warmups: 1000
+
+project_name: D-FINE # for wandb
+exp_name: baseline # eandb experiment name

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ tensorboard
 scipy
 calflops
 transformers
+wandb

--- a/src/core/_config.py
+++ b/src/core/_config.py
@@ -75,9 +75,7 @@ class BaseConfig(object):
         self.device: str = ""
 
     @property
-    def model(
-        self,
-    ) -> nn.Module:
+    def model(self) -> nn.Module:
         return self._model
 
     @model.setter
@@ -86,9 +84,7 @@ class BaseConfig(object):
         self._model = m
 
     @property
-    def postprocessor(
-        self,
-    ) -> nn.Module:
+    def postprocessor(self) -> nn.Module:
         return self._postprocessor
 
     @postprocessor.setter
@@ -97,9 +93,7 @@ class BaseConfig(object):
         self._postprocessor = m
 
     @property
-    def criterion(
-        self,
-    ) -> nn.Module:
+    def criterion(self) -> nn.Module:
         return self._criterion
 
     @criterion.setter
@@ -108,9 +102,7 @@ class BaseConfig(object):
         self._criterion = m
 
     @property
-    def optimizer(
-        self,
-    ) -> Optimizer:
+    def optimizer(self) -> Optimizer:
         return self._optimizer
 
     @optimizer.setter
@@ -121,9 +113,7 @@ class BaseConfig(object):
         self._optimizer = m
 
     @property
-    def lr_scheduler(
-        self,
-    ) -> LRScheduler:
+    def lr_scheduler(self) -> LRScheduler:
         return self._lr_scheduler
 
     @lr_scheduler.setter
@@ -134,9 +124,7 @@ class BaseConfig(object):
         self._lr_scheduler = m
 
     @property
-    def lr_warmup_scheduler(
-        self,
-    ) -> LRScheduler:
+    def lr_warmup_scheduler(self) -> LRScheduler:
         return self._lr_warmup_scheduler
 
     @lr_warmup_scheduler.setter
@@ -184,9 +172,7 @@ class BaseConfig(object):
         self._val_dataloader = loader
 
     @property
-    def ema(
-        self,
-    ) -> nn.Module:
+    def ema(self) -> nn.Module:
         if self._ema is None and self.use_ema and self.model is not None:
             from ..optim import ModelEMA
 
@@ -305,9 +291,7 @@ class BaseConfig(object):
         assert isinstance(m, SummaryWriter), f"{type(m)} must be SummaryWriter"
         self._writer = m
 
-    def __repr__(
-        self,
-    ):
+    def __repr__(self):
         s = ""
         for k, v in self.__dict__.items():
             if not k.startswith("_"):

--- a/src/core/yaml_config.py
+++ b/src/core/yaml_config.py
@@ -30,57 +30,43 @@ class YAMLConfig(BaseConfig):
                 self.__dict__[k] = cfg[k]
 
     @property
-    def global_cfg(
-        self,
-    ):
+    def global_cfg(self):
         return merge_config(self.yaml_cfg, inplace=False, overwrite=False)
 
     @property
-    def model(
-        self,
-    ) -> torch.nn.Module:
+    def model(self) -> torch.nn.Module:
         if self._model is None and "model" in self.yaml_cfg:
             self._model = create(self.yaml_cfg["model"], self.global_cfg)
         return super().model
 
     @property
-    def postprocessor(
-        self,
-    ) -> torch.nn.Module:
+    def postprocessor(self) -> torch.nn.Module:
         if self._postprocessor is None and "postprocessor" in self.yaml_cfg:
             self._postprocessor = create(self.yaml_cfg["postprocessor"], self.global_cfg)
         return super().postprocessor
 
     @property
-    def criterion(
-        self,
-    ) -> torch.nn.Module:
+    def criterion(self) -> torch.nn.Module:
         if self._criterion is None and "criterion" in self.yaml_cfg:
             self._criterion = create(self.yaml_cfg["criterion"], self.global_cfg)
         return super().criterion
 
     @property
-    def optimizer(
-        self,
-    ) -> optim.Optimizer:
+    def optimizer(self) -> optim.Optimizer:
         if self._optimizer is None and "optimizer" in self.yaml_cfg:
             params = self.get_optim_params(self.yaml_cfg["optimizer"], self.model)
             self._optimizer = create("optimizer", self.global_cfg, params=params)
         return super().optimizer
 
     @property
-    def lr_scheduler(
-        self,
-    ) -> optim.lr_scheduler.LRScheduler:
+    def lr_scheduler(self) -> optim.lr_scheduler.LRScheduler:
         if self._lr_scheduler is None and "lr_scheduler" in self.yaml_cfg:
             self._lr_scheduler = create("lr_scheduler", self.global_cfg, optimizer=self.optimizer)
             print(f"Initial lr: {self._lr_scheduler.get_last_lr()}")
         return super().lr_scheduler
 
     @property
-    def lr_warmup_scheduler(
-        self,
-    ) -> optim.lr_scheduler.LRScheduler:
+    def lr_warmup_scheduler(self) -> optim.lr_scheduler.LRScheduler:
         if self._lr_warmup_scheduler is None and "lr_warmup_scheduler" in self.yaml_cfg:
             self._lr_warmup_scheduler = create(
                 "lr_warmup_scheduler", self.global_cfg, lr_scheduler=self.lr_scheduler
@@ -88,41 +74,31 @@ class YAMLConfig(BaseConfig):
         return super().lr_warmup_scheduler
 
     @property
-    def train_dataloader(
-        self,
-    ) -> DataLoader:
+    def train_dataloader(self) -> DataLoader:
         if self._train_dataloader is None and "train_dataloader" in self.yaml_cfg:
             self._train_dataloader = self.build_dataloader("train_dataloader")
         return super().train_dataloader
 
     @property
-    def val_dataloader(
-        self,
-    ) -> DataLoader:
+    def val_dataloader(self) -> DataLoader:
         if self._val_dataloader is None and "val_dataloader" in self.yaml_cfg:
             self._val_dataloader = self.build_dataloader("val_dataloader")
         return super().val_dataloader
 
     @property
-    def ema(
-        self,
-    ) -> torch.nn.Module:
+    def ema(self) -> torch.nn.Module:
         if self._ema is None and self.yaml_cfg.get("use_ema", False):
             self._ema = create("ema", self.global_cfg, model=self.model)
         return super().ema
 
     @property
-    def scaler(
-        self,
-    ):
+    def scaler(self):
         if self._scaler is None and self.yaml_cfg.get("use_amp", False):
             self._scaler = create("scaler", self.global_cfg)
         return super().scaler
 
     @property
-    def evaluator(
-        self,
-    ):
+    def evaluator(self):
         if self._evaluator is None and "evaluator" in self.yaml_cfg:
             if self.yaml_cfg["evaluator"]["type"] == "CocoEvaluator":
                 from ..data import get_coco_api_from_dataset

--- a/train.py
+++ b/train.py
@@ -29,9 +29,7 @@ if debug:
     torch.Tensor.__repr__ = custom_repr
 
 
-def main(
-    args,
-) -> None:
+def main(args) -> None:
     """main"""
     dist_utils.setup_distributed(args.print_rank, args.print_method, seed=args.seed)
 


### PR DESCRIPTION
Adding [Weights and biases](https://wandb.ai/site/) integration.
- In runtime.yaml added configs. 
- Logs mAP metrics, LR, training loss and system info (GPU usage, vRAM, CPU usege...)

For integration to work you will need to log in (free account) first time you run it.

![D-FINE_wandb](https://github.com/user-attachments/assets/e42432f1-b2c8-4623-8efd-8bee04adbe35)


I was training D-FINE on 4 datasets, results are great, but I missed comfortable things like WandB, hence this PR.