### PR TITLE
Add WandB integration and new metrics

### DIFF
--- a/configs/runtime.yml
+++ b/configs/runtime.yml
@@ -18,3 +18,6 @@ ema:
   type: ModelEMA
   decay: 0.9999
   warmups: 1000
+
+project_name: D-FINE # for wandb
+exp_name: baseline # eandb experiment name

--- a/configs/runtime.yml
+++ b/configs/runtime.yml
@@ -20,4 +20,4 @@ ema:
   warmups: 1000
 
 project_name: D-FINE # for wandb
-exp_name: baseline # eandb experiment name
+exp_name: baseline # wandb experiment name

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ tensorboard
 scipy
 calflops
 transformers
+wandb

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ tensorboard
 scipy
 calflops
 transformers
-wandb

--- a/src/core/_config.py
+++ b/src/core/_config.py
@@ -75,9 +75,7 @@ class BaseConfig(object):
         self.device: str = ""
 
     @property
-    def model(
-        self,
-    ) -> nn.Module:
+    def model(self) -> nn.Module:
         return self._model
 
     @model.setter
@@ -86,9 +84,7 @@ class BaseConfig(object):
         self._model = m
 
     @property
-    def postprocessor(
-        self,
-    ) -> nn.Module:
+    def postprocessor(self) -> nn.Module:
         return self._postprocessor
 
     @postprocessor.setter
@@ -97,9 +93,7 @@ class BaseConfig(object):
         self._postprocessor = m
 
     @property
-    def criterion(
-        self,
-    ) -> nn.Module:
+    def criterion(self) -> nn.Module:
         return self._criterion
 
     @criterion.setter
@@ -108,9 +102,7 @@ class BaseConfig(object):
         self._criterion = m
 
     @property
-    def optimizer(
-        self,
-    ) -> Optimizer:
+    def optimizer(self) -> Optimizer:
         return self._optimizer
 
     @optimizer.setter
@@ -121,9 +113,7 @@ class BaseConfig(object):
         self._optimizer = m
 
     @property
-    def lr_scheduler(
-        self,
-    ) -> LRScheduler:
+    def lr_scheduler(self) -> LRScheduler:
         return self._lr_scheduler
 
     @lr_scheduler.setter
@@ -134,9 +124,7 @@ class BaseConfig(object):
         self._lr_scheduler = m
 
     @property
-    def lr_warmup_scheduler(
-        self,
-    ) -> LRScheduler:
+    def lr_warmup_scheduler(self) -> LRScheduler:
         return self._lr_warmup_scheduler
 
     @lr_warmup_scheduler.setter
@@ -184,9 +172,7 @@ class BaseConfig(object):
         self._val_dataloader = loader
 
     @property
-    def ema(
-        self,
-    ) -> nn.Module:
+    def ema(self) -> nn.Module:
         if self._ema is None and self.use_ema and self.model is not None:
             from ..optim import ModelEMA
 
@@ -305,9 +291,7 @@ class BaseConfig(object):
         assert isinstance(m, SummaryWriter), f"{type(m)} must be SummaryWriter"
         self._writer = m
 
-    def __repr__(
-        self,
-    ):
+    def __repr__(self):
         s = ""
         for k, v in self.__dict__.items():
             if not k.startswith("_"):

--- a/src/core/yaml_config.py
+++ b/src/core/yaml_config.py
@@ -30,57 +30,43 @@ class YAMLConfig(BaseConfig):
                 self.__dict__[k] = cfg[k]
 
     @property
-    def global_cfg(
-        self,
-    ):
+    def global_cfg(self):
         return merge_config(self.yaml_cfg, inplace=False, overwrite=False)
 
     @property
-    def model(
-        self,
-    ) -> torch.nn.Module:
+    def model(self) -> torch.nn.Module:
         if self._model is None and "model" in self.yaml_cfg:
             self._model = create(self.yaml_cfg["model"], self.global_cfg)
         return super().model
 
     @property
-    def postprocessor(
-        self,
-    ) -> torch.nn.Module:
+    def postprocessor(self) -> torch.nn.Module:
         if self._postprocessor is None and "postprocessor" in self.yaml_cfg:
             self._postprocessor = create(self.yaml_cfg["postprocessor"], self.global_cfg)
         return super().postprocessor
 
     @property
-    def criterion(
-        self,
-    ) -> torch.nn.Module:
+    def criterion(self) -> torch.nn.Module:
         if self._criterion is None and "criterion" in self.yaml_cfg:
             self._criterion = create(self.yaml_cfg["criterion"], self.global_cfg)
         return super().criterion
 
     @property
-    def optimizer(
-        self,
-    ) -> optim.Optimizer:
+    def optimizer(self) -> optim.Optimizer:
         if self._optimizer is None and "optimizer" in self.yaml_cfg:
             params = self.get_optim_params(self.yaml_cfg["optimizer"], self.model)
             self._optimizer = create("optimizer", self.global_cfg, params=params)
         return super().optimizer
 
     @property
-    def lr_scheduler(
-        self,
-    ) -> optim.lr_scheduler.LRScheduler:
+    def lr_scheduler(self) -> optim.lr_scheduler.LRScheduler:
         if self._lr_scheduler is None and "lr_scheduler" in self.yaml_cfg:
             self._lr_scheduler = create("lr_scheduler", self.global_cfg, optimizer=self.optimizer)
             print(f"Initial lr: {self._lr_scheduler.get_last_lr()}")
         return super().lr_scheduler
 
     @property
-    def lr_warmup_scheduler(
-        self,
-    ) -> optim.lr_scheduler.LRScheduler:
+    def lr_warmup_scheduler(self) -> optim.lr_scheduler.LRScheduler:
         if self._lr_warmup_scheduler is None and "lr_warmup_scheduler" in self.yaml_cfg:
             self._lr_warmup_scheduler = create(
                 "lr_warmup_scheduler", self.global_cfg, lr_scheduler=self.lr_scheduler
@@ -88,41 +74,31 @@ class YAMLConfig(BaseConfig):
         return super().lr_warmup_scheduler
 
     @property
-    def train_dataloader(
-        self,
-    ) -> DataLoader:
+    def train_dataloader(self) -> DataLoader:
         if self._train_dataloader is None and "train_dataloader" in self.yaml_cfg:
             self._train_dataloader = self.build_dataloader("train_dataloader")
         return super().train_dataloader
 
     @property
-    def val_dataloader(
-        self,
-    ) -> DataLoader:
+    def val_dataloader(self) -> DataLoader:
         if self._val_dataloader is None and "val_dataloader" in self.yaml_cfg:
             self._val_dataloader = self.build_dataloader("val_dataloader")
         return super().val_dataloader
 
     @property
-    def ema(
-        self,
-    ) -> torch.nn.Module:
+    def ema(self) -> torch.nn.Module:
         if self._ema is None and self.yaml_cfg.get("use_ema", False):
             self._ema = create("ema", self.global_cfg, model=self.model)
         return super().ema
 
     @property
-    def scaler(
-        self,
-    ):
+    def scaler(self):
         if self._scaler is None and self.yaml_cfg.get("use_amp", False):
             self._scaler = create("scaler", self.global_cfg)
         return super().scaler
 
     @property
-    def evaluator(
-        self,
-    ):
+    def evaluator(self):
         if self._evaluator is None and "evaluator" in self.yaml_cfg:
             if self.yaml_cfg["evaluator"]["type"] == "CocoEvaluator":
                 from ..data import get_coco_api_from_dataset

--- a/src/solver/_solver.py
+++ b/src/solver/_solver.py
@@ -151,6 +151,13 @@ class BaseSolver(object):
             if dist_utils.is_main_process():
                 self.writer.add_text("config", "{:s}".format(cfg.__repr__()), 0)
 
+        try:
+            import wandb
+
+            self.use_wandb = True
+        except ImportError:
+            self.use_wandb = False
+
     def cleanup(self):
         if self.writer:
             atexit.register(self.writer.close)

--- a/src/solver/det_engine.py
+++ b/src/solver/det_engine.py
@@ -8,18 +8,19 @@ Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 
 import math
 import sys
-from typing import Iterable
+from ast import List
+from typing import Dict, Iterable
 
 import numpy as np
 import torch
 import torch.amp
-import wandb
 from torch.cuda.amp.grad_scaler import GradScaler
 from torch.utils.tensorboard import SummaryWriter
 
 from ..data import CocoEvaluator
 from ..misc import MetricLogger, SmoothedValue, dist_utils
 from ..optim import ModelEMA, Warmup
+from .validator import Validator, scale_boxes
 
 
 def train_one_epoch(
@@ -29,9 +30,13 @@ def train_one_epoch(
     optimizer: torch.optim.Optimizer,
     device: torch.device,
     epoch: int,
+    use_wandb: bool,
     max_norm: float = 0,
     **kwargs,
 ):
+    if use_wandb:
+        import wandb
+
     model.train()
     criterion.train()
     metric_logger = MetricLogger(delimiter="  ")
@@ -123,9 +128,10 @@ def train_one_epoch(
             for k, v in loss_dict_reduced.items():
                 writer.add_scalar(f"Loss/{k}", v.item(), global_step)
 
-    wandb.log(
-        {"lr": optimizer.param_groups[0]["lr"], "epoch": epoch, "train/loss": np.mean(losses)}
-    )
+    if use_wandb:
+        wandb.log(
+            {"lr": optimizer.param_groups[0]["lr"], "epoch": epoch, "train/loss": np.mean(losses)}
+        )
     # gather the stats from all processes
     metric_logger.synchronize_between_processes()
     print("Averaged stats:", metric_logger)
@@ -140,7 +146,12 @@ def evaluate(
     data_loader,
     coco_evaluator: CocoEvaluator,
     device,
+    epoch: int,
+    use_wandb: bool,
 ):
+    if use_wandb:
+        import wandb
+
     model.eval()
     criterion.eval()
     coco_evaluator.cleanup()
@@ -153,6 +164,9 @@ def evaluate(
     iou_types = coco_evaluator.iou_types
     # coco_evaluator = CocoEvaluator(base_ds, iou_types)
     # coco_evaluator.coco_eval[iou_types[0]].params.iouThrs = [0, 0.1, 0.5, 0.75]
+
+    gt: List[Dict[str, torch.Tensor]] = []
+    preds: List[Dict[str, torch.Tensor]] = []
 
     for samples, targets in metric_logger.log_every(data_loader, 10, header):
         samples = samples.to(device)
@@ -175,6 +189,30 @@ def evaluate(
         res = {target["image_id"].item(): output for target, output in zip(targets, results)}
         if coco_evaluator is not None:
             coco_evaluator.update(res)
+
+        # validator format for metrics
+        for idx, (target, result) in enumerate(zip(targets, results)):
+            gt.append(
+                {
+                    "boxes": scale_boxes(  # from model input size to original img size
+                        torch.tensor(target["boxes"].tolist()).to(device),
+                        (target["orig_size"][1], target["orig_size"][0]),
+                        (samples[idx].shape[-1], samples[idx].shape[-2]),
+                    ),
+                    "labels": target["labels"],
+                }
+            )
+            preds.append(
+                {"boxes": result["boxes"], "labels": result["labels"], "scores": result["scores"]}
+            )
+
+    # Conf matrix, F1, Precision, Recall, box IoU
+    metrics = Validator(gt, preds).compute_metrics()
+    print("Metrics:", metrics)
+    if use_wandb:
+        metrics = {f"metrics/{k}": v for k, v in metrics.items()}
+        metrics["epoch"] = epoch
+        wandb.log(metrics)
 
     # gather the stats from all processes
     metric_logger.synchronize_between_processes()

--- a/src/solver/det_solver.py
+++ b/src/solver/det_solver.py
@@ -11,7 +11,6 @@ import json
 import time
 
 import torch
-import wandb
 
 from ..misc import dist_utils, stats
 from ._solver import BaseSolver
@@ -24,12 +23,15 @@ class DetSolver(BaseSolver):
         args = self.cfg
         metric_names = ["AP50:95", "AP50", "AP75", "APsmall", "APmedium", "APlarge"]
 
-        wandb.init(
-            project=args.yaml_cfg["project_name"],
-            name=args.yaml_cfg["exp_name"],
-            config=args.yaml_cfg,
-        )
-        wandb.watch(self.model)
+        if self.use_wandb:
+            import wandb
+
+            wandb.init(
+                project=args.yaml_cfg["project_name"],
+                name=args.yaml_cfg["exp_name"],
+                config=args.yaml_cfg,
+            )
+            wandb.watch(self.model)
 
         n_parameters, model_stats = stats(self.cfg)
         print(model_stats)
@@ -81,6 +83,7 @@ class DetSolver(BaseSolver):
                 scaler=self.scaler,
                 lr_warmup_scheduler=self.lr_warmup_scheduler,
                 writer=self.writer,
+                use_wandb=self.use_wandb,
             )
 
             if self.lr_warmup_scheduler is None or self.lr_warmup_scheduler.finished():
@@ -104,6 +107,8 @@ class DetSolver(BaseSolver):
                 self.val_dataloader,
                 self.evaluator,
                 self.device,
+                epoch,
+                self.use_wandb,
             )
 
             # TODO
@@ -165,11 +170,12 @@ class DetSolver(BaseSolver):
                 "n_parameters": n_parameters,
             }
 
-            wandb_logs = {}
-            for idx, metric_name in enumerate(metric_names):
-                wandb_logs[f"metrics/{metric_name}"] = test_stats["coco_eval_bbox"][idx]
-            wandb_logs["epoch"] = epoch
-            wandb.log(wandb_logs)
+            if self.use_wandb:
+                wandb_logs = {}
+                for idx, metric_name in enumerate(metric_names):
+                    wandb_logs[f"metrics/{metric_name}"] = test_stats["coco_eval_bbox"][idx]
+                wandb_logs["epoch"] = epoch
+                wandb.log(wandb_logs)
 
             if self.output_dir and dist_utils.is_main_process():
                 with (self.output_dir / "log.txt").open("a") as f:
@@ -203,6 +209,8 @@ class DetSolver(BaseSolver):
             self.val_dataloader,
             self.evaluator,
             self.device,
+            epoch=-1,
+            use_wandb=False,
         )
 
         if self.output_dir:

--- a/src/solver/validator.py
+++ b/src/solver/validator.py
@@ -1,0 +1,350 @@
+import copy
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List
+
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+from loguru import logger
+from torchvision.ops import box_iou
+
+
+class Validator:
+    def __init__(
+        self,
+        gt: List[Dict[str, torch.Tensor]],
+        preds: List[Dict[str, torch.Tensor]],
+        conf_thresh=0.5,
+        iou_thresh=0.5,
+    ) -> None:
+        """
+        Format example:
+        gt = [{'labels': tensor([0]), 'boxes': tensor([[561.0, 297.0, 661.0, 359.0]])}, ...]
+        len(gt) is the number of images
+        bboxes are in format [x1, y1, x2, y2], absolute values
+        """
+        self.gt = gt
+        self.preds = preds
+        self.conf_thresh = conf_thresh
+        self.iou_thresh = iou_thresh
+        self.thresholds = np.arange(0.2, 1.0, 0.05)
+        self.conf_matrix = None
+
+    def compute_metrics(self, extended=False) -> Dict[str, float]:
+        print(torch.max(self.preds[0]["scores"]))
+        print(torch.max(self.preds[0]["boxes"]))
+        print(torch.max(self.gt[0]["boxes"]))
+
+        filtered_preds = filter_preds(copy.deepcopy(self.preds), self.conf_thresh)
+        metrics = self._compute_main_metrics(filtered_preds)
+        if not extended:
+            metrics.pop("extended_metrics", None)
+        return metrics
+
+    def _compute_main_metrics(self, preds):
+        (
+            self.metrics_per_class,
+            self.conf_matrix,
+            self.class_to_idx,
+        ) = self._compute_metrics_and_confusion_matrix(preds)
+        tps, fps, fns = 0, 0, 0
+        ious = []
+        extended_metrics = {}
+        for key, value in self.metrics_per_class.items():
+            tps += value["TPs"]
+            fps += value["FPs"]
+            fns += value["FNs"]
+            ious.extend(value["IoUs"])
+
+            extended_metrics[f"precision_{key}"] = (
+                value["TPs"] / (value["TPs"] + value["FPs"])
+                if value["TPs"] + value["FPs"] > 0
+                else 0
+            )
+            extended_metrics[f"recall_{key}"] = (
+                value["TPs"] / (value["TPs"] + value["FNs"])
+                if value["TPs"] + value["FNs"] > 0
+                else 0
+            )
+
+            extended_metrics[f"iou_{key}"] = np.mean(value["IoUs"])
+
+        precision = tps / (tps + fps) if (tps + fps) > 0 else 0
+        recall = tps / (tps + fns) if (tps + fns) > 0 else 0
+        f1 = 2 * (precision * recall) / (precision + recall) if (precision + recall) > 0 else 0
+        return {
+            "f1": f1,
+            "precision": precision,
+            "recall": recall,
+            "iou": np.mean(ious) if ious else 0,
+            "TPs": tps,
+            "FPs": fps,
+            "FNs": fns,
+            "extended_metrics": extended_metrics,
+        }
+
+    def _compute_matrix_multi_class(self, preds):
+        metrics_per_class = defaultdict(lambda: {"TPs": 0, "FPs": 0, "FNs": 0, "IoUs": []})
+        for pred, gt in zip(preds, self.gt):
+            pred_boxes = pred["boxes"]
+            pred_labels = pred["labels"]
+            gt_boxes = gt["boxes"]
+            gt_labels = gt["labels"]
+
+            # isolate each class
+            labels = torch.unique(torch.cat([pred_labels, gt_labels]))
+            for label in labels:
+                pred_cl_boxes = pred_boxes[pred_labels == label]  # filter by bool mask
+                gt_cl_boxes = gt_boxes[gt_labels == label]
+
+                n_preds = len(pred_cl_boxes)
+                n_gts = len(gt_cl_boxes)
+                if not (n_preds or n_gts):
+                    continue
+                if not n_preds:
+                    metrics_per_class[label.item()]["FNs"] += n_gts
+                    metrics_per_class[label.item()]["IoUs"].extend([0] * n_gts)
+                    continue
+                if not n_gts:
+                    metrics_per_class[label.item()]["FPs"] += n_preds
+                    metrics_per_class[label.item()]["IoUs"].extend([0] * n_preds)
+                    continue
+
+                ious = box_iou(pred_cl_boxes, gt_cl_boxes)  # matrix of all IoUs
+                ious_mask = ious >= self.iou_thresh
+
+                # indeces of boxes that have IoU >= threshold
+                pred_indices, gt_indices = torch.nonzero(ious_mask, as_tuple=True)
+
+                if not pred_indices.numel():  # no predicts matched gts
+                    metrics_per_class[label.item()]["FNs"] += n_gts
+                    metrics_per_class[label.item()]["IoUs"].extend([0] * n_gts)
+                    metrics_per_class[label.item()]["FPs"] += n_preds
+                    metrics_per_class[label.item()]["IoUs"].extend([0] * n_preds)
+                    continue
+
+                iou_values = ious[pred_indices, gt_indices]
+
+                # sorting by IoU to match hgihest scores first
+                sorted_indices = torch.argsort(-iou_values)
+                pred_indices = pred_indices[sorted_indices]
+                gt_indices = gt_indices[sorted_indices]
+                iou_values = iou_values[sorted_indices]
+
+                matched_preds = set()
+                matched_gts = set()
+                for pred_idx, gt_idx, iou in zip(pred_indices, gt_indices, iou_values):
+                    if gt_idx.item() not in matched_gts and pred_idx.item() not in matched_preds:
+                        matched_preds.add(pred_idx.item())
+                        matched_gts.add(gt_idx.item())
+                        metrics_per_class[label.item()]["TPs"] += 1
+                        metrics_per_class[label.item()]["IoUs"].append(iou.item())
+
+                unmatched_preds = set(range(n_preds)) - matched_preds
+                unmatched_gts = set(range(n_gts)) - matched_gts
+                metrics_per_class[label.item()]["FPs"] += len(unmatched_preds)
+                metrics_per_class[label.item()]["IoUs"].extend([0] * len(unmatched_preds))
+                metrics_per_class[label.item()]["FNs"] += len(unmatched_gts)
+                metrics_per_class[label.item()]["IoUs"].extend([0] * len(unmatched_gts))
+        return metrics_per_class
+
+    def _compute_metrics_and_confusion_matrix(self, preds):
+        # Initialize per-class metrics
+        metrics_per_class = defaultdict(lambda: {"TPs": 0, "FPs": 0, "FNs": 0, "IoUs": []})
+
+        # Collect all class IDs
+        all_classes = set()
+        for pred in preds:
+            all_classes.update(pred["labels"].tolist())
+        for gt in self.gt:
+            all_classes.update(gt["labels"].tolist())
+        all_classes = sorted(list(all_classes))
+        class_to_idx = {cls_id: idx for idx, cls_id in enumerate(all_classes)}
+        n_classes = len(all_classes)
+        conf_matrix = np.zeros((n_classes + 1, n_classes + 1), dtype=int)  # +1 for background class
+
+        for pred, gt in zip(preds, self.gt):
+            pred_boxes = pred["boxes"]
+            pred_labels = pred["labels"]
+            gt_boxes = gt["boxes"]
+            gt_labels = gt["labels"]
+
+            n_preds = len(pred_boxes)
+            n_gts = len(gt_boxes)
+
+            if n_preds == 0 and n_gts == 0:
+                continue
+
+            ious = box_iou(pred_boxes, gt_boxes) if n_preds > 0 and n_gts > 0 else torch.tensor([])
+            # Assign matches between preds and gts
+            matched_pred_indices = set()
+            matched_gt_indices = set()
+
+            if ious.numel() > 0:
+                # For each pred box, find the gt box with highest IoU
+                ious_mask = ious >= self.iou_thresh
+                pred_indices, gt_indices = torch.nonzero(ious_mask, as_tuple=True)
+                iou_values = ious[pred_indices, gt_indices]
+
+                # Sorting by IoU to match highest scores first
+                sorted_indices = torch.argsort(-iou_values)
+                pred_indices = pred_indices[sorted_indices]
+                gt_indices = gt_indices[sorted_indices]
+                iou_values = iou_values[sorted_indices]
+
+                for pred_idx, gt_idx, iou in zip(pred_indices, gt_indices, iou_values):
+                    if (
+                        pred_idx.item() in matched_pred_indices
+                        or gt_idx.item() in matched_gt_indices
+                    ):
+                        continue
+                    matched_pred_indices.add(pred_idx.item())
+                    matched_gt_indices.add(gt_idx.item())
+
+                    pred_label = pred_labels[pred_idx].item()
+                    gt_label = gt_labels[gt_idx].item()
+
+                    pred_cls_idx = class_to_idx[pred_label]
+                    gt_cls_idx = class_to_idx[gt_label]
+
+                    # Update confusion matrix
+                    conf_matrix[gt_cls_idx, pred_cls_idx] += 1
+
+                    # Update per-class metrics
+                    if pred_label == gt_label:
+                        metrics_per_class[gt_label]["TPs"] += 1
+                        metrics_per_class[gt_label]["IoUs"].append(iou.item())
+                    else:
+                        # Misclassification
+                        metrics_per_class[gt_label]["FNs"] += 1
+                        metrics_per_class[pred_label]["FPs"] += 1
+                        metrics_per_class[gt_label]["IoUs"].append(0)
+                        metrics_per_class[pred_label]["IoUs"].append(0)
+
+            # Unmatched predictions (False Positives)
+            unmatched_pred_indices = set(range(n_preds)) - matched_pred_indices
+            for pred_idx in unmatched_pred_indices:
+                pred_label = pred_labels[pred_idx].item()
+                pred_cls_idx = class_to_idx[pred_label]
+                # Update confusion matrix: background row
+                conf_matrix[n_classes, pred_cls_idx] += 1
+                # Update per-class metrics
+                metrics_per_class[pred_label]["FPs"] += 1
+                metrics_per_class[pred_label]["IoUs"].append(0)
+
+            # Unmatched ground truths (False Negatives)
+            unmatched_gt_indices = set(range(n_gts)) - matched_gt_indices
+            for gt_idx in unmatched_gt_indices:
+                gt_label = gt_labels[gt_idx].item()
+                gt_cls_idx = class_to_idx[gt_label]
+                # Update confusion matrix: background column
+                conf_matrix[gt_cls_idx, n_classes] += 1
+                # Update per-class metrics
+                metrics_per_class[gt_label]["FNs"] += 1
+                metrics_per_class[gt_label]["IoUs"].append(0)
+
+        return metrics_per_class, conf_matrix, class_to_idx
+
+    def save_plots(self, path_to_save) -> None:
+        path_to_save = Path(path_to_save)
+        path_to_save.mkdir(parents=True, exist_ok=True)
+
+        if self.conf_matrix is not None:
+            class_labels = [str(cls_id) for cls_id in self.class_to_idx.keys()] + ["background"]
+
+            plt.figure(figsize=(10, 8))
+            plt.imshow(self.conf_matrix, interpolation="nearest", cmap=plt.cm.Blues)
+            plt.title("Confusion Matrix")
+            plt.colorbar()
+            tick_marks = np.arange(len(class_labels))
+            plt.xticks(tick_marks, class_labels, rotation=45)
+            plt.yticks(tick_marks, class_labels)
+
+            # Add labels to each cell
+            thresh = self.conf_matrix.max() / 2.0
+            for i in range(self.conf_matrix.shape[0]):
+                for j in range(self.conf_matrix.shape[1]):
+                    plt.text(
+                        j,
+                        i,
+                        format(self.conf_matrix[i, j], "d"),
+                        horizontalalignment="center",
+                        color="white" if self.conf_matrix[i, j] > thresh else "black",
+                    )
+
+            plt.ylabel("True label")
+            plt.xlabel("Predicted label")
+            plt.tight_layout()
+            plt.savefig(path_to_save / "confusion_matrix.png")
+            plt.close()
+
+        thresholds = self.thresholds
+        precisions, recalls, f1_scores = [], [], []
+
+        # Store the original predictions to reset after each threshold
+        original_preds = copy.deepcopy(self.preds)
+
+        for threshold in thresholds:
+            # Filter predictions based on the current threshold
+            filtered_preds = filter_preds(copy.deepcopy(original_preds), threshold)
+            # Compute metrics with the filtered predictions
+            metrics = self._compute_main_metrics(filtered_preds)
+            precisions.append(metrics["precision"])
+            recalls.append(metrics["recall"])
+            f1_scores.append(metrics["f1"])
+
+        # Plot Precision and Recall vs Threshold
+        plt.figure()
+        plt.plot(thresholds, precisions, label="Precision", marker="o")
+        plt.plot(thresholds, recalls, label="Recall", marker="o")
+        plt.xlabel("Threshold")
+        plt.ylabel("Value")
+        plt.title("Precision and Recall vs Threshold")
+        plt.legend()
+        plt.grid(True)
+        plt.savefig(path_to_save / "precision_recall_vs_threshold.png")
+        plt.close()
+
+        # Plot F1 Score vs Threshold
+        plt.figure()
+        plt.plot(thresholds, f1_scores, label="F1 Score", marker="o")
+        plt.xlabel("Threshold")
+        plt.ylabel("F1 Score")
+        plt.title("F1 Score vs Threshold")
+        plt.grid(True)
+        plt.savefig(path_to_save / "f1_score_vs_threshold.png")
+        plt.close()
+
+        # Find the best threshold based on F1 Score (last occurence)
+        best_idx = len(f1_scores) - np.argmax(f1_scores[::-1]) - 1
+        best_threshold = thresholds[best_idx]
+        best_f1 = f1_scores[best_idx]
+
+        logger.info(
+            f"Best Threshold: {round(best_threshold, 2)} with F1 Score: {round(best_f1, 3)}"
+        )
+
+
+def filter_preds(preds, conf_thresh):
+    for pred in preds:
+        keep_idxs = pred["scores"] >= conf_thresh
+        pred["scores"] = pred["scores"][keep_idxs]
+        pred["boxes"] = pred["boxes"][keep_idxs]
+        pred["labels"] = pred["labels"][keep_idxs]
+    return preds
+
+
+def scale_boxes(boxes, orig_shape, resized_shape):
+    """
+    boxes in format: [x1, y1, x2, y2], absolute values
+    orig_shape: [height, width]
+    resized_shape: [height, width]
+    """
+    scale_x = orig_shape[1] / resized_shape[1]
+    scale_y = orig_shape[0] / resized_shape[0]
+    boxes[:, 0] *= scale_x
+    boxes[:, 2] *= scale_x
+    boxes[:, 1] *= scale_y
+    boxes[:, 3] *= scale_y
+    return boxes

--- a/train.py
+++ b/train.py
@@ -29,9 +29,7 @@ if debug:
     torch.Tensor.__repr__ = custom_repr
 
 
-def main(
-    args,
-) -> None:
+def main(args) -> None:
     """main"""
     dist_utils.setup_distributed(args.print_rank, args.print_method, seed=args.seed)
 


### PR DESCRIPTION
Adding [Weights and biases](https://wandb.ai/site/) integration and metrics: F1-score, Precision, Recall, TPs, FPs, FNs, box IoU. New metrics are calculated with a fixed threshold.

- In runtime.yaml added configs for WandB
- Wandb Logs mAP and new metrics, LR, training loss and system info (GPU usage, vRAM, CPU usege...)
- WandB is not required, if user has it installed - it will be used.
- New class to calculate all new metrics.

![d-fine_wandb](https://github.com/user-attachments/assets/b423f301-eb4b-41e4-acb6-87476d779b04)

I was training D-FINE on 4 datasets, results are great, but I missed comfortable things like WandB and F1-score, hence this PR. People should pay less attention to mAPs when working on a real world tasks, as mAP is calculated with different conf thresholds, but on prod we always fix conf threshold, so it's good to know real world metrics like F1-score.