### PR TITLE
Add image path to COCO dataset target dictionary

### DIFF
--- a/src/data/dataset/coco_dataset.py
+++ b/src/data/dataset/coco_dataset.py
@@ -10,6 +10,7 @@ import faster_coco_eval.core.mask as coco_mask
 import torch
 import torch.utils.data
 import torchvision
+import os
 from PIL import Image
 
 from ...core import register
@@ -50,7 +51,8 @@ class CocoDetection(torchvision.datasets.CocoDetection, DetDataset):
     def load_item(self, idx):
         image, target = super(CocoDetection, self).__getitem__(idx)
         image_id = self.ids[idx]
-        target = {"image_id": image_id, "annotations": target}
+        image_path = os.path.join(self.img_folder, self.coco.loadImgs(image_id)[0]["file_name"])
+        target = {"image_id": image_id, "image_path": image_path, "annotations": target}
 
         if self.remap_mscoco_category:
             image, target = self.prepare(image, target, category2label=mscoco_category2label)
@@ -130,6 +132,8 @@ class ConvertCocoPolysToMask(object):
         image_id = target["image_id"]
         image_id = torch.tensor([image_id])
 
+        image_path = target["image_path"]
+
         anno = target["annotations"]
 
         anno = [obj for obj in anno if "iscrowd" not in obj or obj["iscrowd"] == 0]
@@ -175,6 +179,7 @@ class ConvertCocoPolysToMask(object):
         if self.return_masks:
             target["masks"] = masks
         target["image_id"] = image_id
+        target["image_path"] = image_path
         if keypoints is not None:
             target["keypoints"] = keypoints
 

--- a/src/solver/det_engine.py
+++ b/src/solver/det_engine.py
@@ -55,7 +55,7 @@ def train_one_epoch(
         metric_logger.log_every(data_loader, print_freq, header)
     ):
         samples = samples.to(device)
-        targets = [{k: v.to(device) for k, v in t.items()} for t in targets]
+        targets = [{k: v.to(device) if isinstance(v, torch.Tensor) else v for k, v in t.items()} for t in targets]
         global_step = epoch * len(data_loader) + i
         metas = dict(epoch=epoch, step=i, global_step=global_step, epoch_step=len(data_loader))
 
@@ -170,7 +170,7 @@ def evaluate(
 
     for samples, targets in metric_logger.log_every(data_loader, 10, header):
         samples = samples.to(device)
-        targets = [{k: v.to(device) for k, v in t.items()} for t in targets]
+        targets = [{k: v.to(device) if isinstance(v, torch.Tensor) else v for k, v in t.items()} for t in targets]
 
         outputs = model(samples)
         # with torch.autocast(device_type=str(device)):


### PR DESCRIPTION
Add image path to COCO dataset target dictionary

- Modify CocoDetection.load_item() to include the full image path in the target dictionary
- Update ConvertCocoPolysToMask to preserve the image path in the processed target
- Enables easier access to the original image file path during dataset processing

It's hard to debug with `image_id` only.