### PR TITLE
Fix crash when evaluating background-only images

### DIFF
--- a/src/solver/det_engine.py
+++ b/src/solver/det_engine.py
@@ -195,7 +195,7 @@ def evaluate(
             gt.append(
                 {
                     "boxes": scale_boxes(  # from model input size to original img size
-                        torch.tensor(target["boxes"].tolist()).to(device),
+                        target["boxes"],
                         (target["orig_size"][1], target["orig_size"][0]),
                         (samples[idx].shape[-1], samples[idx].shape[-2]),
                     ),


### PR DESCRIPTION
Fix crash when evaluating background-only images

command: `python train.py -c configs/dfine/dfine_hgnetv2_n_coco.yml --test-only -r dfine_n_coco.pth`

# Before 

<img width="1091" alt="image" src="https://github.com/user-attachments/assets/c27ff9b7-4bc6-498c-acb7-dfbdabe731c2" />

# After

![image](https://github.com/user-attachments/assets/0a944090-d6f2-43f7-8dc5-2c5c5d706a93)


Removed unnecessary conversion:

```python
torch.tensor(target["boxes"].tolist()).to(device),
```
since this conversion is already performed before the iteration.

```python
for samples, targets in metric_logger.log_every(data_loader, 10, header):
        samples = samples.to(device)
        targets = [{k: v.to(device) if isinstance(v, torch.Tensor) else v for k, v in t.items()} for t in targets]
```
