### PR TITLE
Refactor COCO evaluation stats collection in det_engine

### DIFF
--- a/src/solver/det_engine.py
+++ b/src/solver/det_engine.py
@@ -217,17 +217,15 @@ def evaluate(
     # gather the stats from all processes
     metric_logger.synchronize_between_processes()
     print("Averaged stats:", metric_logger)
+    stats = {}
+    # stats = {k: meter.global_avg for k, meter in metric_logger.meters.items()}    
     if coco_evaluator is not None:
         coco_evaluator.synchronize_between_processes()
 
-    # accumulate predictions from all images
-    if coco_evaluator is not None:
+        # accumulate predictions from all images
         coco_evaluator.accumulate()
         coco_evaluator.summarize()
 
-    stats = {}
-    # stats = {k: meter.global_avg for k, meter in metric_logger.meters.items()}
-    if coco_evaluator is not None:
         if "bbox" in iou_types:
             stats["coco_eval_bbox"] = coco_evaluator.coco_eval["bbox"].stats.tolist()
         if "segm" in iou_types:


### PR DESCRIPTION
Refactor COCO evaluation stats collection in det_engine

Modify the stats collection process in the evaluate method:
- Move stats dictionary initialization before COCO evaluator synchronization
- Simplify stats collection for COCO evaluation metrics
- Preserve commented-out code for potential future use