### PR TITLE
Fix IoU calculation to use .item() for numpy mean

### DIFF
--- a/src/solver/validator.py
+++ b/src/solver/validator.py
@@ -69,11 +69,12 @@ class Validator:
         precision = tps / (tps + fps) if (tps + fps) > 0 else 0
         recall = tps / (tps + fns) if (tps + fns) > 0 else 0
         f1 = 2 * (precision * recall) / (precision + recall) if (precision + recall) > 0 else 0
+        iou = np.mean(ious).item() if ious else 0
         return {
             "f1": f1,
             "precision": precision,
             "recall": recall,
-            "iou": np.mean(ious) if ious else 0,
+            "iou": iou,
             "TPs": tps,
             "FPs": fps,
             "FNs": fns,


### PR DESCRIPTION
CC: @ArgoHA 

# Before

<img width="755" alt="image" src="https://github.com/user-attachments/assets/79936b99-6a1c-43ba-ab2d-591cb0f62191" />


# After

<img width="782" alt="image" src="https://github.com/user-attachments/assets/40d6895a-6fa5-417e-bc28-929ebb003a70" />
