### PR TITLE
Fix resume training

### DIFF
--- a/src/solver/det_solver.py
+++ b/src/solver/det_solver.py
@@ -49,6 +49,8 @@ class DetSolver(BaseSolver):
                 self.val_dataloader,
                 self.evaluator,
                 self.device,
+                self.last_epoch,
+                self.use_wandb
             )
             for k in test_stats:
                 best_stat["epoch"] = self.last_epoch


### PR DESCRIPTION
This PR fixes an issue where resuming interrupted training would fail due to missing parameters in the `evaluate()` function call.

## Problem:

PR #177 introduced two new parameters (`epoch` and `use_wandb`) to the `evaluate()` function in `det_engine.py`
The `det_solver.py` file's resume training path wasn't updated to pass these parameters, causing crashes with `TypeError: evaluate() missing 2 required positional arguments` when using `--resume`
## Changes:

Updated the `evaluate()` function call in `det_solver.py` during resume operations to include the missing `epoch` and `use_wandb` parameters
Ensured parameter values align with the training context during resumption
## Impact:

Fixes crashing behavior when resuming interrupted training sessions
Maintains consistency with the W&B logging feature added in PR #177
This resolves the parameter mismatch while preserving all existing functionality.