### PR TITLE
OpenVino Second Model Input Should be i64

### DIFF
--- a/tools/inference/openvino_inf.py
+++ b/tools/inference/openvino_inf.py
@@ -57,9 +57,10 @@ class OvInfer:
                 ori_image, self.target_size, interpolation=cv2.INTER_LINEAR
             )
         blob_image = cv2.dnn.blobFromImage(self.resized_image, 1.0 / 255.0)
-        orig_size = np.array([self.resized_image.shape[0], self.resized_image.shape[1]]).reshape(
+        orig_size = np.array([self.resized_image.shape[0], self.resized_image.shape[1]], dtype=np.int64).reshape(
             1, 2
         )
+
         inputs = {
             "images": blob_image,
             "orig_target_sizes": orig_size,


### PR DESCRIPTION
Running OpenVino failed for me giving the error:

```powershell
RuntimeError: Exception from src\inference\src\cpp\infer_request.cpp:79:
Exception from src\inference\src\cpp\infer_request.cpp:66:
Exception from src\plugins\intel_cpu\src\infer_request.cpp:379:
ParameterMismatch: Failed to set tensor for input with precision: i32, since the model input tensor precision is: i64
```

I had converted a `.pth` model into ONNX and then OpenVino using the `mo` tool.