### PR TITLE
fix: replace unsafe yaml.Loader with yaml.SafeLoader (CWE-502)

### DIFF
--- a/src/core/yaml_utils.py
+++ b/src/core/yaml_utils.py
@@ -28,7 +28,7 @@ def load_config(file_path, cfg=dict()):
     assert ext in [".yml", ".yaml"], "only support yaml files"
 
     with open(file_path) as f:
-        file_cfg = yaml.load(f, Loader=yaml.Loader)
+        file_cfg = yaml.load(f, Loader=yaml.SafeLoader)
         if file_cfg is None:
             return {}
 
@@ -85,7 +85,7 @@ def parse_cli(nargs: List[str]) -> Dict:
     for s in nargs:
         s = s.strip()
         k, v = s.split("=", 1)
-        d = dictify(k, yaml.load(v, Loader=yaml.Loader))
+        d = dictify(k, yaml.load(v, Loader=yaml.SafeLoader))
         cfg = merge_dict(cfg, d)
 
     return cfg


### PR DESCRIPTION
yaml.Loader allows arbitrary Python object construction from YAML tags, enabling remote code execution via malicious config files. Since D-FINE configs only use plain mappings/lists/scalars, yaml.SafeLoader is a drop-in replacement with no functional change.

Fixes #354