### PR TITLE
README: add a community Android (LiteRT GPU) port to Deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,6 +548,8 @@ python tools/deployment/export_onnx.py --check -c configs/dfine/dfine_hgnetv2_${
 trtexec --onnx="model.onnx" --saveEngine="model.engine" --fp16
 ```
 
+4. Android (LiteRT GPU, community port) — D-FINE-S as `.tflite` on the LiteRT CompiledModel GPU with a Kotlin sample app: [LiteRT-Models › D-FINE-S](https://github.com/john-rocky/LiteRT-Models#d-fine-s) (~450 ms/frame on a Pixel 8a, still-image; IoU 0.99–1.00 vs PyTorch)
+
 </details>
 
 <details>


### PR DESCRIPTION
Thanks for the Deployment block in the Tools section. This adds a fourth step to it for an Android build of D-FINE-S: the `dfine-small-coco` weights converted to LiteRT (.tflite) and running fully on the phone GPU through the LiteRT CompiledModel API, with a Kotlin sample app.

- Pixel 8a: both graphs fully GPU-resident (511/511 and 850/850 ops); about 450 ms per frame end-to-end, so still-image use rather than real-time. The number is in the line so nobody expects otherwise.
- Detections match PyTorch at IoU 0.99–1.00 on a COCO val image, with matching class and score.
- Apache-2.0 is kept, and the zoo section links back to this repo.

Zoo section: https://github.com/john-rocky/LiteRT-Models#d-fine-s — weights: https://huggingface.co/litert-community/D-FINE-S-LiteRT

Happy to reword or drop it if the block should stay ONNX/TensorRT only. Thanks again.
